### PR TITLE
Spelling Error - stateDidChange -> storeDidChange

### DIFF
--- a/006-flux.html
+++ b/006-flux.html
@@ -72,7 +72,7 @@
             getInitialState: function(){
                 return getRecipes();
             },
-            stateDidChange: function() {
+            storeDidChange: function() {
                 this.setState(getRecipes());
             },
             render: function() {


### PR DESCRIPTION
stateDidChange method within RecipesController method should be storeDidChange not stateDidChange. I believe this was just a spelling error based on commit af7e113ac765e0941957f7fa4fbe8273f2d964c5
