### PR TITLE
add npm start script to run local web-server for easier file viewing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Branches of this repo cover the concepts of react and flux in a hands on way",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start" : "http-server -p 9009"
   },
   "author": "",
   "license": "BSD-2-Clause",
   "dependencies": {
     "mcfly": "0.0.8"
+  },
+  "devDependencies": {
+    "http-server": "^0.8.0"
   }
 }


### PR DESCRIPTION
Added a dev-dependency of `http-server`, and added a `start` script to launch  a server that can be accessed on `http://localhost:9009`.

This should make things a bit easier for many folks, instead of trying to enable the `file://` protocol in your browser of choice, setting up your own server, or needing to use an editor with built in connect.

To use, simply run `npm start` in your terminal, and then in your browser address bar, go to `http://localhost:9009`
