### PR TITLE
teach controlled components concept

### DIFF
--- a/006.2-flux-form-broken.html
+++ b/006.2-flux-form-broken.html
@@ -111,6 +111,7 @@
                 RecipeActions.deleteRecipe(index);
             },
             render: function() {
+                var self = this;
                 var recipeNodes = this.props.recipes.map(function(recipe, index){
                         return <li key={index}>Recipe {recipe} <button type="button" onClick={self.deleteRecipe.bind(self, index)}>Delete</button></li>
                     })


### PR DESCRIPTION
I noticed that this file did not have "var self = this" in the Recipe component. Since, this file was to show the controlled components concept, it would make sense that the delete functionality still work like it does in 006.1-flux-form.html
